### PR TITLE
feat(python): Add URL and SSH repo input support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "explainthisrepo"
-version = "0.2.2"
+version = "0.2.3"
 description = "ExplainThisRepo is a CLI developer tool to quickly explain GitHub repository in plain English"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
### What changed

Normalize repository input.
Accept multiple GitHub repo formats.
Convert all inputs to owner/repo internally.

---

### Newly supported input formats

Support full HTTPS GitHub URLs.
Support github.com URLs without scheme.
Support SSH clone URLs.
Handle common http/https typo cases.
Strip query strings.
Strip URL fragments.
Remove .git suffix safely.

Examples now valid:

* [https://github.com/owner/repo](https://github.com/owner/repo)
* github.com/owner/repo
* [https://github.com/owner/repo/issues/123](https://github.com/owner/repo/issues/123)
* [https://github.com/owner/repo?tab=readme](https://github.com/owner/repo?tab=readme)
* [[git@github.com](mailto:git@github.com)](mailto:git@github.com):owner/repo.git

All normalize to owner and repo before processing.

---

### Validation improvements

Enforce strict GitHub domain check.
Reject non-repository GitHub pages.
Fail fast on malformed SSH URLs.

---

### Impact

No changes to engine logic.
No changes to modes.
No changes to output.

Improves CLI ergonomics only.
Reduces user input errors.
Matches behavior of mature developer CLIs.
