### PR TITLE
feat(cli): support GitHub URLs and SSH clone links as input (node)

### DIFF
--- a/node_version/package-lock.json
+++ b/node_version/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "explainthisrepo",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "explainthisrepo",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",

--- a/node_version/package.json
+++ b/node_version/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explainthisrepo",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "ExplainThisRepo is a CLI developer tool to explain any GitHub repository in plain English",
   "license": "MIT",
   "type": "module",

--- a/node_version/prompt.ts
+++ b/node_version/prompt.ts
@@ -35,8 +35,7 @@ Rules:
   }
 
   // NORMAL / DETAILED MODE
-  let prompt = `
-You are a senior software engineer.
+  let prompt = `You are a senior software engineer.
 
 Your task is to explain a GitHub repository clearly and concisely for a human reader.
 
@@ -73,7 +72,7 @@ Additional instructions:
 - Mention important files and their roles.
 `;
   }
-
+  
   prompt += `
 
 Output format:


### PR DESCRIPTION
CLI now accepts:
- `owner/repo`
- `https://github.com/owner/repo`
- `github.com/owner/repo`
- `git@github.com:owner/repo.git`

Previously only owner/repo worked.