### PR TITLE
chore(dev): expand Makefile to support Node build, run, doctor and real tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup install dev test build publish clean lint format doctor
+.PHONY: setup install dev test build publish clean lint format doctor build-node run-node doctor-node
 
 setup: install dev
 
@@ -10,13 +10,14 @@ dev:
 	pip install -e .
 
 test:
-	python -m explain_this_repo --version
+	pytest
 
 lint:
 	python -m pyflakes explain_this_repo
 
 format:
 	python -m black explain_this_repo
+	python -m isort explain_this_repo
 
 build: clean
 	python -m build
@@ -27,5 +28,16 @@ publish: build
 doctor:
 	python -m explain_this_repo --doctor
 
+# Node targets
+build-node:
+	cd node_version && npm install && npm run build
+
+run-node:
+	node node_version/dist/cli.js facebook/react
+
+doctor-node:
+	node node_version/dist/cli.js --doctor
+
 clean:
 	rm -rf dist build *.egg-info
+	rm -rf node_version/dist node_version/node_modules


### PR DESCRIPTION
Expanded dev tooling. Improves local workflow
- Added Node build support via Makefile
- Added Node run shortcut
- Added Node doctor command shortcut
- Added real test command instead of placeholder
- Aligns Python and Node dev flows
- No user-facing CLI behavior changed
- Dev experience and contributor setup improved