### PR TITLE
docs: redesign documentation site with dark mode and improved the UX

### DIFF
--- a/apps/web/public/docs/index.html
+++ b/apps/web/public/docs/index.html
@@ -3,18 +3,50 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ExplainThisRepo - Docs</title>
-    <link rel="stylesheet" href="css/style.css">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=JetBrains+Mono:wght@400&display=swap" rel="stylesheet">
+    <title>ExplainThisRepo - Documentation</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
     <style>
     /* --- RESET & VARIABLES --- */
     :root {
-        --bg-sidebar: #f8fafc;
+        --bg-primary: #ffffff;
+        --bg-secondary: #f8fafc;
+        --bg-sidebar: #fafafa;
         --border-color: #e2e8f0;
-        --primary: #3b82f6;
+        --border-hover: #cbd5e1;
+        --primary: #2563eb;
+        --primary-hover: #1d4ed8;
         --text-dark: #0f172a;
-        --text-gray: #475569;
-        --code-bg: #1e293b;
+        --text-medium: #334155;
+        --text-gray: #64748b;
+        --code-bg: #020817;
+        --code-border: #1e293b;
+        --success: #16a34a;
+        --warning: #f59e0b;
+        --copy-btn: #475569;
+        --copy-hover: #334155;
+        --inline-code-bg: #f1f5f9;
+        --inline-code-text: #e11d48;
+    }
+
+    [data-theme="dark"] {
+        --bg-primary: #0f172a;
+        --bg-secondary: #1e293b;
+        --bg-sidebar: #1e293b;
+        --border-color: #334155;
+        --border-hover: #475569;
+        --primary: #3b82f6;
+        --primary-hover: #60a5fa;
+        --text-dark: #f1f5f9;
+        --text-medium: #cbd5e1;
+        --text-gray: #94a3b8;
+        --code-bg: #020817;
+        --code-border: #1e293b;
+        --success: #22c55e;
+        --warning: #fbbf24;
+        --copy-btn: #64748b;
+        --copy-hover: #94a3b8;
+        --inline-code-bg: #334155;
+        --inline-code-text: #fca5a5;
     }
 
     * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -22,15 +54,26 @@
     body {
         font-family: 'Inter', sans-serif;
         color: var(--text-dark);
-        line-height: 1.6;
+        line-height: 1.7;
+        background: var(--bg-primary);
         display: flex;
         min-height: 100vh;
+        transition: background-color 0.3s ease, color 0.3s ease;
+    }
+
+    code {
+        font-family: 'JetBrains Mono', monospace;
+        font-size: 0.9em;
+        background: var(--inline-code-bg);
+        padding: 0.15rem 0.4rem;
+        border-radius: 4px;
+        color: var(--inline-code-text);
     }
 
     /* --- LAYOUT --- */
     .docs-layout {
         display: grid;
-        grid-template-columns: 260px 1fr; /* Sidebar fixed width, Content fluid */
+        grid-template-columns: 280px 1fr;
         width: 100%;
     }
 
@@ -38,197 +81,485 @@
     .sidebar {
         background: var(--bg-sidebar);
         border-right: 1px solid var(--border-color);
-        padding: 2rem;
+        padding: 2rem 1.5rem;
         position: fixed;
         height: 100vh;
-        width: 260px;
+        width: 280px;
         overflow-y: auto;
+        transition: background-color 0.3s ease, border-color 0.3s ease;
     }
 
     .brand {
         font-weight: 800;
-        font-size: 1.2rem;
+        font-size: 1.25rem;
         margin-bottom: 2.5rem;
+        color: var(--text-dark);
+        letter-spacing: -0.02em;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+    }
+
+    .brand-link {
+        color: var(--text-dark);
+        text-decoration: none;
+        transition: color 0.2s ease;
+    }
+
+    .brand-link:hover {
         color: var(--primary);
+    }
+
+    .theme-toggle {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        width: 36px;
+        height: 36px;
+        border-radius: 8px;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: all 0.3s ease;
+        color: var(--text-dark);
+    }
+
+    .theme-toggle:hover {
+        background: var(--border-color);
+        transform: scale(1.05);
+    }
+
+    .theme-toggle svg {
+        width: 18px;
+        height: 18px;
+    }
+
+    .sun-icon {
+        display: block;
+    }
+
+    .moon-icon {
+        display: none;
+    }
+
+    .nav-section {
+        margin-bottom: 2rem;
     }
 
     .nav-label {
         text-transform: uppercase;
-        font-size: 0.75rem;
+        font-size: 0.7rem;
         font-weight: 700;
-        color: #94a3b8;
-        margin-top: 1.5rem;
-        margin-bottom: 0.5rem;
-        letter-spacing: 0.05em;
+        color: var(--text-gray);
+        margin-bottom: 0.75rem;
+        letter-spacing: 0.08em;
     }
 
     .sidebar a {
         display: block;
         text-decoration: none;
-        color: var(--text-gray);
-        font-size: 0.95rem;
-        padding: 0.4rem 0;
-        transition: color 0.2s;
+        color: var(--text-medium);
+        font-size: 0.9rem;
+        padding: 0.5rem 0.75rem;
+        border-radius: 6px;
+        transition: all 0.2s;
+        margin-bottom: 0.25rem;
     }
 
-    .sidebar a:hover, .sidebar a.active {
+    .sidebar a:hover {
+        background: #f1f5f9;
+        color: var(--text-dark);
+    }
+
+    .sidebar a.active {
+        background: #eff6ff;
         color: var(--primary);
         font-weight: 500;
     }
 
-    /* --- MAIN CONTENT AREA --- */
+    /* --- MAIN CONTENT --- */
     .main-content {
         grid-column: 2;
-        padding: 4rem 6rem;
-        max-width: 1000px;
+        padding: 3rem 4rem;
+        max-width: 1100px;
     }
 
     .divider {
         border: 0;
         border-top: 1px solid var(--border-color);
-        margin: 4rem 0;
+        margin: 3.5rem 0;
     }
 
-    /* --- HEADINGS --- */
-    .intro-wrapper h1 {
-        font-size: clamp(1.8rem, 5vw, 3rem);
+    /* --- TYPOGRAPHY --- */
+    h1 {
+        font-size: clamp(2rem, 5vw, 2.75rem);
+        font-weight: 800;
         letter-spacing: -0.03em;
-        margin-bottom: 1.5rem;
+        margin-bottom: 1rem;
+        color: var(--text-dark);
     }
 
-    .technical-wrapper h2 {
+    h2 {
         font-size: clamp(1.5rem, 4vw, 2rem);
         font-weight: 700;
+        letter-spacing: -0.02em;
+        margin-bottom: 1.25rem;
+        color: var(--text-dark);
     }
 
-    .intro-wrapper .lead {
-        font-size: 1.3rem;
+    h3 {
+        font-size: 1.25rem;
+        font-weight: 600;
+        margin-bottom: 0.75rem;
+        color: var(--text-dark);
+    }
+
+    .lead {
+        font-size: 1.2rem;
         font-weight: 400;
-        color: #334155;
-        line-height: 1.7;
-        margin-bottom: 2rem;
-    }
-
-    /* Cards for conceptual features */
-    .feature-grid {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 1.5rem;
-        margin-top: 2rem;
-    }
-
-    .feature-card {
-        background: #fff;
-        border: 1px solid var(--border-color);
-        padding: 1.5rem;
-        border-radius: 8px;
-        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
-    }
-
-    .feature-card h3 { font-size: 1.1rem; margin-bottom: 0.5rem; }
-    .feature-card p { font-size: 0.9rem; color: var(--text-gray); }
-
-    /* --- INSTALLATION & TERMINALS --- */
-    .technical-wrapper .tech-header {
-        display: flex;
-        align-items: center;
-        gap: 1rem;
+        color: var(--text-medium);
+        line-height: 1.8;
         margin-bottom: 1.5rem;
+    }
+
+    p {
+        color: var(--text-medium);
+        margin-bottom: 1rem;
+    }
+
+    /* --- BADGES --- */
+    .badges {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin: 1.5rem 0;
+    }
+
+    .badge-img {
+        height: 20px;
     }
 
     .tag {
         background: #eff6ff;
         color: var(--primary);
-        padding: 0.2rem 0.6rem;
-        border-radius: 99px;
+        padding: 0.25rem 0.75rem;
+        border-radius: 6px;
         font-size: 0.8rem;
         font-weight: 600;
         font-family: 'JetBrains Mono', monospace;
+        display: inline-block;
     }
 
-    .terminal {
-        background: var(--code-bg);
-        border-radius: 8px;
-        margin: 1.5rem 0;
-        box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
-        font-family: 'JetBrains Mono', monospace;
-        overflow-x: auto; /* allow horizontal scroll on small screens */
-        word-break: break-word;
+    /* Shadcn-style badges for section titles */
+    .section-badge {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 9999px;
+        border: 1px solid var(--border-color);
+        background: var(--bg-secondary);
+        padding: 0.25rem 0.75rem;
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: var(--text-medium);
+        transition: all 0.2s ease;
     }
 
-    .terminal-bar {
-        background: #334155;
-        padding: 0.5rem 1rem;
+    [data-theme="dark"] .section-badge {
+        border-color: var(--border-color);
+        background: var(--bg-sidebar);
+    }
+
+    .section-header {
         display: flex;
         align-items: center;
-        gap: 6px;
+        gap: 0.75rem;
+        margin-bottom: 1.25rem;
     }
 
-    .dot { height: 10px; width: 10px; border-radius: 50%; display: inline-block; }
-    .red { background: #ef4444; } .yellow { background: #fbbf24; } .green { background: #22c55e; }
-
-    .terminal-title {
-        margin-left: auto;
-        color: #94a3b8;
-        font-size: 0.75rem;
+    .section-header h2 {
+        margin-bottom: 0;
     }
 
-    .terminal-content {
+    /* --- FEATURE GRID --- */
+    .feature-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 1rem;
+        margin: 2rem 0;
+    }
+
+    .feature-card {
+        background: var(--bg-primary);
+        border: 1px solid var(--border-color);
         padding: 1.5rem;
-        color: #f1f5f9;
+        border-radius: 8px;
+        transition: all 0.3s ease;
+    }
+
+    .feature-card:hover {
+        border-color: var(--border-hover);
+        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
+    }
+
+    .feature-card h3 {
         font-size: 1rem;
-    }
-
-    .prompt { color: #c084fc; margin-right: 0.5rem; user-select: none; }
-
-    .alert-box {
-        background: #fffbeb;
-        border-left: 4px solid #f59e0b;
-        padding: 1rem;
-        color: #92400e;
-        font-size: 0.95rem;
-        border-radius: 4px;
-    }
-
-    .install-option { margin-bottom: 2.5rem; }
-
-    .install-option h3 {
-        font-size: 1.1rem;
-        font-weight: 600;
         margin-bottom: 0.5rem;
         display: flex;
         align-items: center;
         gap: 0.5rem;
     }
 
-    .badge {
+    .feature-card p {
+        font-size: 0.9rem;
+        color: var(--text-gray);
+        margin: 0;
+    }
+
+    /* --- TERMINAL / CODE BLOCKS --- */
+    .terminal {
+        background: var(--code-bg);
+        border: 1px solid var(--code-border);
+        border-radius: 8px;
+        margin: 1.5rem 0;
+        overflow: hidden;
+        position: relative;
+        box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+    }
+
+    .terminal-bar {
+        background: #0f172a;
+        padding: 0.65rem 1rem;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        border-bottom: 1px solid var(--code-border);
+    }
+
+    .dot { 
+        height: 10px; 
+        width: 10px; 
+        border-radius: 50%; 
+        display: inline-block; 
+    }
+    .red { background: #ef4444; } 
+    .yellow { background: #fbbf24; } 
+    .green { background: #22c55e; }
+
+    .terminal-title {
+        margin-left: auto;
+        color: #64748b;
+        font-size: 0.75rem;
+        font-family: 'JetBrains Mono', monospace;
+    }
+
+    .terminal-content {
+        padding: 1.5rem;
+        color: #f1f5f9;
+        font-size: 0.95rem;
+        font-family: 'JetBrains Mono', monospace;
+        overflow-x: auto;
+        position: relative;
+    }
+
+    .prompt { 
+        color: #a78bfa; 
+        margin-right: 0.5rem; 
+        user-select: none; 
+        font-weight: 500;
+    }
+
+    .comment { 
+        color: #64748b; 
+        font-style: italic; 
+    }
+
+    .copy-btn {
+        position: absolute;
+        top: 0.75rem;
+        right: 1rem;
+        background: var(--copy-btn);
+        color: #fff;
+        border: none;
+        padding: 0.4rem 0.75rem;
+        border-radius: 6px;
+        font-size: 0.75rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.2s;
+        font-family: 'Inter', sans-serif;
+        z-index: 10;
+    }
+
+    .copy-btn:hover {
+        background: var(--copy-hover);
+    }
+
+    .copy-btn.copied {
+        background: var(--success);
+    }
+
+    /* --- ALERTS --- */
+    .alert-box {
+        background: #fffbeb;
+        border-left: 4px solid var(--warning);
+        padding: 1rem 1.25rem;
+        color: #92400e;
+        font-size: 0.9rem;
+        border-radius: 6px;
+        margin: 1.5rem 0;
+        transition: background-color 0.3s ease;
+    }
+
+    [data-theme="dark"] .alert-box {
+        background: #422006;
+        color: #fde68a;
+    }
+
+    .alert-box strong {
+        font-weight: 600;
+    }
+
+    .alert-info {
+        background: #eff6ff;
+        border-left: 4px solid var(--primary);
+        color: #1e40af;
+    }
+
+    [data-theme="dark"] .alert-info {
+        background: #1e3a8a;
+        color: #bfdbfe;
+    }
+
+    /* --- INSTALL OPTIONS --- */
+    .install-option {
+        margin-bottom: 2.5rem;
+    }
+
+    .option-header {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        margin-bottom: 0.75rem;
+    }
+
+    .option-badge {
         font-size: 0.7rem;
         text-transform: uppercase;
-        padding: 2px 8px;
+        padding: 0.2rem 0.6rem;
         border-radius: 4px;
         font-weight: 700;
         letter-spacing: 0.05em;
     }
 
-    .badge.recommended {
+    .option-badge.recommended {
         background-color: #dcfce7;
         color: #166534;
-        border: 1px solid #bbf7d0;
+        border: 1px solid #86efac;
     }
 
-    .terminal-content .comment {
-        color: #64748b;
-        font-style: italic;
-    }
-
-    .badge.py-badge {
-        background-color: #fffae0;
-        color: #b45309;
+    .option-badge.python {
+        background-color: #fef3c7;
+        color: #92400e;
         border: 1px solid #fde68a;
     }
 
-    /* --- RESPONSIVE FIXES --- */
-    @media (max-width: 768px) {
+    /* --- MODES SECTION --- */
+    .modes-grid {
+        display: grid;
+        gap: 1rem;
+        margin: 2rem 0;
+    }
+
+    .mode-item {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        padding: 1.25rem;
+        border-radius: 8px;
+        transition: background-color 0.3s ease, border-color 0.3s ease;
+    }
+
+    .mode-item h3 {
+        font-family: 'JetBrains Mono', monospace;
+        font-size: 1rem;
+        color: var(--primary);
+        margin-bottom: 0.5rem;
+    }
+
+    .mode-item p {
+        font-size: 0.9rem;
+        margin: 0;
+    }
+
+    /* --- FLEXIBLE INPUT EXAMPLES --- */
+    .input-examples {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        padding: 1.5rem;
+        border-radius: 8px;
+        margin: 1.5rem 0;
+        transition: background-color 0.3s ease, border-color 0.3s ease;
+    }
+
+    .input-examples h3 {
+        font-size: 1rem;
+        margin-bottom: 1rem;
+    }
+
+    .input-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    .input-example {
+        font-family: 'JetBrains Mono', monospace;
+        font-size: 0.85rem;
+        color: var(--text-medium);
+        padding: 0.5rem;
+        background: var(--bg-primary);
+        border-radius: 4px;
+        transition: background-color 0.3s ease, color 0.3s ease;
+    }
+
+    /* --- SCREENSHOTS --- */
+    .screenshot-placeholder {
+        background: #f1f5f9;
+        border: 2px dashed var(--border-color);
+        border-radius: 8px;
+        padding: 3rem;
+        text-align: center;
+        color: var(--text-gray);
+        margin: 1.5rem 0;
+    }
+
+    /* --- FOOTER --- */
+    .footer {
+        margin-top: 4rem;
+        padding-top: 2rem;
+        border-top: 1px solid var(--border-color);
+        color: var(--text-gray);
+        font-size: 0.9rem;
+    }
+
+    .footer-links {
+        display: flex;
+        gap: 1.5rem;
+        margin-top: 1rem;
+    }
+
+    .footer-links a {
+        color: var(--primary);
+        text-decoration: none;
+        transition: color 0.2s;
+    }
+
+    .footer-links a:hover {
+        color: var(--primary-hover);
+        text-decoration: underline;
+    }
+
+    /* --- RESPONSIVE --- */
+    @media (max-width: 968px) {
         .docs-layout {
             display: block;
         }
@@ -236,35 +567,75 @@
             position: relative;
             width: 100%;
             height: auto;
-            padding: 1rem;
+            padding: 1.5rem;
+            border-right: none;
+            border-bottom: 1px solid var(--border-color);
         }
         .main-content {
-            padding: 2rem 1rem;
+            padding: 2rem 1.5rem;
         }
         .feature-grid {
-            grid-template-columns: 1fr; /* stack feature cards vertically */
+            grid-template-columns: 1fr;
         }
+    }
+
+    @media (max-width: 640px) {
+        .main-content {
+            padding: 1.5rem 1rem;
+        }
+        h1 {
+            font-size: 1.75rem;
+        }
+        h2 {
+            font-size: 1.5rem;
+        }
+    }
+
+    /* Smooth scrolling */
+    html {
+        scroll-behavior: smooth;
     }
     </style>
 </head>
 <body>
     <div class="docs-layout">
+        <!-- SIDEBAR -->
         <aside class="sidebar">
-            <div class="brand">ExplainThisRepo</div>
+            <div class="brand">
+                <a href="https://explainthisrepo.com" class="brand-link">ExplainThisRepo</a>
+                <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
+                    <svg class="sun-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"></path>
+                    </svg>
+                    <svg class="moon-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path>
+                    </svg>
+                </button>
+            </div>
             <nav>
-                <p class="nav-label">Overview</p>
-                <a href="#introduction" class="active">Introduction</a>
-                <a href="#features">Key Features</a>
-                <p class="nav-label">Get Started</p>
-                <a href="#installation">Installation</a>
-                <a href="#usage">Basic Usage</a>
-                <a href="#config">Configuration</a>
-                <a href="#termux">Termux (Android) install notes</a>
+                <div class="nav-section">
+                    <p class="nav-label">Overview</p>
+                    <a href="#introduction" class="active">Introduction</a>
+                    <a href="#features">Key Features</a>
+                    <a href="#modes">Modes</a>
+                </div>
+                <div class="nav-section">
+                    <p class="nav-label">Getting Started</p>
+                    <a href="#installation">Installation</a>
+                    <a href="#flexible-input">Flexible Input</a>
+                    <a href="#usage">Usage</a>
+                    <a href="#configuration">Configuration</a>
+                </div>
+                <div class="nav-section">
+                    <p class="nav-label">Special Cases</p>
+                    <a href="#termux">Termux (Android)</a>
+                </div>
             </nav>
         </aside>
 
+        <!-- MAIN CONTENT -->
         <main class="main-content">
-            <!-- Introduction -->
+            <!-- INTRODUCTION -->
             <section id="introduction" class="intro-wrapper">
                 <h1>Introduction</h1>
                 <p class="lead">
@@ -285,213 +656,585 @@
                 </div>
             </section>
 
-                        <hr class="divider">
+            <hr class="divider">
 
-           
-            <section id="installation" class="technical-wrapper">
-                <div class="tech-header">
-                    <h2>Installation</h2>
+            <!-- KEY FEATURES -->
+            <section id="features">
+                <div class="section-header">
+                    <h2>Key Features</h2>
+                    <span class="section-badge">⚡ Powerful</span>
                 </div>
+                <div class="feature-grid">
+                    <div class="feature-card">
+                        <h3>🔍 Auto-Fetch</h3>
+                        <p>Fetches public GitHub repositories automatically</p>
+                    </div>
+                    <div class="feature-card">
+                        <h3>📊 Structure Analysis</h3>
+                        <p>Analyzes repository structure and high-signal source files, not just README</p>
+                    </div>
+                    <div class="feature-card">
+                        <h3>🎯 Signal Extraction</h3>
+                        <p>Extracts repo signals from key files (package.json, pyproject.toml, config files, entrypoints)</p>
+                    </div>
+                    <div class="feature-card">
+                        <h3>🌲 File Tree</h3>
+                        <p>Builds a file tree summary to understand project architecture</p>
+                    </div>
+                    <div class="feature-card">
+                        <h3>🔧 Language Detection</h3>
+                        <p>Detects programming languages via the GitHub API</p>
+                    </div>
+                    <div class="feature-card">
+                        <h3>🔗 Flexible Input</h3>
+                        <p>Accepts repositories via owner/repo, GitHub URLs, issue/PR links, and SSH clone links</p>
+                    </div>
+                    <div class="feature-card">
+                        <h3>📝 Plain English</h3>
+                        <p>Generates clear explanations in plain English</p>
+                    </div>
+                    <div class="feature-card">
+                        <h3>💾 Output</h3>
+                        <p>Outputs an EXPLAIN.md file in your current directory (default mode)</p>
+                    </div>
+                    <div class="feature-card">
+                        <h3>🎛️ Multi-Mode CLI</h3>
+                        <p>Multiple command-line modes for different use cases</p>
+                    </div>
+                </div>
+            </section>
+
+            <hr class="divider">
+
+            <!-- MODES -->
+            <section id="modes">
+                <div class="section-header">
+                    <h2>Modes</h2>
+                    <span class="section-badge">🧭 Flexible</span>
+                </div>
+                <p>ExplainThisRepo supports multiple modes to fit different workflows:</p>
                 
+                <div class="modes-grid">
+                    <div class="mode-item">
+                        <h3>(no flag)</h3>
+                        <p>Full repository explanation written to EXPLAIN.md</p>
+                    </div>
+                    <div class="mode-item">
+                        <h3>--quick</h3>
+                        <p>One-sentence summary</p>
+                    </div>
+                    <div class="mode-item">
+                        <h3>--simple</h3>
+                        <p>Short, easy explanation</p>
+                    </div>
+                    <div class="mode-item">
+                        <h3>--detailed</h3>
+                        <p>Deeper explanation including structure and architecture</p>
+                    </div>
+                    <div class="mode-item">
+                        <h3>--stack</h3>
+                        <p>Tech stack breakdown from repo signals</p>
+                    </div>
+                    <div class="mode-item">
+                        <h3>--version</h3>
+                        <p>Show CLI version</p>
+                    </div>
+                    <div class="mode-item">
+                        <h3>--help</h3>
+                        <p>Show usage guide</p>
+                    </div>
+                    <div class="mode-item">
+                        <h3>--doctor</h3>
+                        <p>Check environment + connectivity (useful for debugging)</p>
+                    </div>
+                </div>
+            </section>
+
+            <hr class="divider">
+
+            <!-- INSTALLATION -->
+            <section id="installation">
+                <div class="section-header">
+                    <h2>Installation</h2>
+                    <span class="section-badge">📦 Easy Setup</span>
+                </div>
                 <p>Choose the installation method that fits your environment.</p>
-            
+
                 <div class="install-option">
-                    <h3>Option 1: Run with npm / npx  (recommended for most devs)</h3>
-                    <p>No Python setup required. Runs anywhere Node runs.</p>
+                    <div class="option-header">
+                        <h3>Option 1: Install via pip</h3>
+                        <span class="option-badge recommended">Recommended</span>
+                    </div>
+                    <p>Requirements: Python 3.9+</p>
                     
                     <div class="terminal">
                         <div class="terminal-bar">
-                            <span class="dot red"></span><span class="dot yellow"></span><span class="dot green"></span>
+                            <span class="dot red"></span>
+                            <span class="dot yellow"></span>
+                            <span class="dot green"></span>
                             <span class="terminal-title">bash</span>
                         </div>
                         <div class="terminal-content">
-                            <span class="comment"># Run immediately without installing</span><br>
-                            <span class="prompt">$</span> npx explainthisrepo owner/repo<br><br>
-                            <span class="comment"># Or install globally</span><br>
-                            <span class="prompt">$</span> npm install -g explainthisrepo
+                            <button class="copy-btn" onclick="copyToClipboard(this, 'pip install explainthisrepo\nexplainthisrepo owner/repo')">Copy</button>
+                            <span class="prompt">$</span> pip install explainthisrepo<br>
+                            <span class="prompt">$</span> explainthisrepo owner/repo
+                        </div>
+                    </div>
+
+                    <p style="margin-top: 1rem;">Alternatively, use pipx:</p>
+                    
+                    <div class="terminal">
+                        <div class="terminal-bar">
+                            <span class="dot red"></span>
+                            <span class="dot yellow"></span>
+                            <span class="dot green"></span>
+                            <span class="terminal-title">bash</span>
+                        </div>
+                        <div class="terminal-content">
+                            <button class="copy-btn" onclick="copyToClipboard(this, 'pipx install explainthisrepo\nexplainthisrepo owner/repo')">Copy</button>
+                            <span class="prompt">$</span> pipx install explainthisrepo<br>
+                            <span class="prompt">$</span> explainthisrepo owner/repo
                         </div>
                     </div>
                 </div>
-            
+
                 <div class="install-option">
-                    <h3>Option 2: Install via pip <span class="badge py-badge">Python</span></h3>
-                    <p>Recommended for most Python developers.</p>
-                    
-                    <div class="terminal">
-                        <div class="terminal-bar">
-                            <span class="dot red"></span><span class="dot yellow"></span><span class="dot green"></span>
-                            <span class="terminal-title">bash</span>
-                        </div>
-                        <div class="terminal-content">
-                            <span class="prompt">$</span> pip install explainthisrepo
-                        </div>
+                    <div class="option-header">
+                        <h3>Option 2: Install with npm</h3>
                     </div>
-                </div>
-            
-                <div class="install-option">
-                    <h3>Option 3: Install with pipx <span class="badge py-badge">Python</span></h3>
-                    <p>Best for isolating CLI tools from your system dependencies.</p>
+                    <p>Install globally and use forever:</p>
                     
                     <div class="terminal">
                         <div class="terminal-bar">
-                            <span class="dot red"></span><span class="dot yellow"></span><span class="dot green"></span>
+                            <span class="dot red"></span>
+                            <span class="dot yellow"></span>
+                            <span class="dot green"></span>
                             <span class="terminal-title">bash</span>
                         </div>
                         <div class="terminal-content">
-                            <span class="prompt">$</span> pipx install explainthisrepo
+                            <button class="copy-btn" onclick="copyToClipboard(this, 'npm install -g explainthisrepo\nexplainthisrepo owner/repo')">Copy</button>
+                            <span class="prompt">$</span> npm install -g explainthisrepo<br>
+                            <span class="prompt">$</span> explainthisrepo owner/repo<br>
+                            <span class="comment"># or: npx explainthisrepo owner/repo</span>
                         </div>
                     </div>
                 </div>
             </section>
-            
-            <section id="usage" class="technical-wrapper">
-                <hr class="divider">
-                
-                <div class="tech-header">
-                    <h2>🧪 Usage</h2>
+
+            <hr class="divider">
+
+            <!-- FLEXIBLE INPUT -->
+            <section id="flexible-input">
+                <div class="section-header">
+                    <h2>Flexible Repository Input</h2>
+                    <span class="section-badge">🔗 Smart</span>
                 </div>
-            
-                <p>The basic command structure is straightforward:</p>
-            
+                <p>You don't need to reformat links anymore.</p>
+                <p>ExplainThisRepo accepts GitHub repositories the way you actually copy them:</p>
+
+                <div class="input-examples">
+                    <h3>All these formats work:</h3>
+                    <div class="input-list">
+                        <div class="input-example">explainthisrepo https://github.com/owner/repo</div>
+                        <div class="input-example">explainthisrepo github.com/owner/repo</div>
+                        <div class="input-example">explainthisrepo https://github.com/owner/repo/issues/123</div>
+                        <div class="input-example">explainthisrepo https://github.com/owner/repo?tab=readme</div>
+                        <div class="input-example">explainthisrepo <a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="3e59574a7e59574a564b5c105d5153">[email&#160;protected]</a>:owner/repo.git</div>
+                    </div>
+                </div>
+
+                <div class="alert-box alert-info">
+                    All inputs are normalized internally to <code>owner/repo</code>. No change to engine behavior. Just less friction.
+                </div>
+            </section>
+
+            <hr class="divider">
+
+            <!-- USAGE -->
+            <section id="usage">
+                <div class="section-header">
+                    <h2>Usage</h2>
+                    <span class="section-badge">🧪 Examples</span>
+                </div>
+
+                <h3>Basic</h3>
+                <p>Generate a full explanation and save it to <code>EXPLAIN.md</code>:</p>
+                
                 <div class="terminal">
                     <div class="terminal-bar">
-                        <span class="dot red"></span><span class="dot yellow"></span><span class="dot green"></span>
+                        <span class="dot red"></span>
+                        <span class="dot yellow"></span>
+                        <span class="dot green"></span>
                         <span class="terminal-title">bash</span>
                     </div>
                     <div class="terminal-content">
+                        <button class="copy-btn" onclick="copyToClipboard(this, 'explainthisrepo owner/repo')">Copy</button>
                         <span class="prompt">$</span> explainthisrepo owner/repo
                     </div>
                 </div>
-            
-                <br>
-            
-                <div class="tech-header">
-                    <h2>🧾 Example</h2>
-                </div>
-            
-                <p>Here is how you would explain the React repository:</p>
-            
+
+                <p style="margin-top: 1rem;">Example:</p>
+                
                 <div class="terminal">
                     <div class="terminal-bar">
-                        <span class="dot red"></span><span class="dot yellow"></span><span class="dot green"></span>
+                        <span class="dot red"></span>
+                        <span class="dot yellow"></span>
+                        <span class="dot green"></span>
                         <span class="terminal-title">bash</span>
                     </div>
                     <div class="terminal-content">
+                        <button class="copy-btn" onclick="copyToClipboard(this, 'explainthisrepo facebook/react')">Copy</button>
                         <span class="prompt">$</span> explainthisrepo facebook/react
                     </div>
                 </div>
-            </section>
-            <section id="configuration" class="technical-wrapper">
-                <hr class="divider">
-            
-                <div class="tech-header" id="config">
-                    <h2>⚙️ Configuration</h2>
+
+                <h3 style="margin-top: 2.5rem;">Quick mode</h3>
+                <p>Get a one-sentence definition (prints only, no file created):</p>
+                
+                <div class="terminal">
+                    <div class="terminal-bar">
+                        <span class="dot red"></span>
+                        <span class="dot yellow"></span>
+                        <span class="dot green"></span>
+                        <span class="terminal-title">bash</span>
+                    </div>
+                    <div class="terminal-content">
+                        <button class="copy-btn" onclick="copyToClipboard(this, 'explainthisrepo owner/repo --quick')">Copy</button>
+                        <span class="prompt">$</span> explainthisrepo owner/repo --quick
+                    </div>
                 </div>
-            
-                <p>
-                    ExplainThisRepo relies on Google's Gemini models to generate explanations. 
-                    You must set your API key as an environment variable before running the tool.
-                </p>
-            
+
+                <p style="margin-top: 1rem;">Example:</p>
+                
+                <div class="terminal">
+                    <div class="terminal-bar">
+                        <span class="dot red"></span>
+                        <span class="dot yellow"></span>
+                        <span class="dot green"></span>
+                        <span class="terminal-title">bash</span>
+                    </div>
+                    <div class="terminal-content">
+                        <button class="copy-btn" onclick="copyToClipboard(this, 'explainthisrepo facebook/react --quick')">Copy</button>
+                        <span class="prompt">$</span> explainthisrepo facebook/react --quick
+                    </div>
+                </div>
+
+                <h3 style="margin-top: 2.5rem;">Detailed mode</h3>
+                <p>Generate a more detailed explanation (includes architecture / folder structure):</p>
+                
+                <div class="terminal">
+                    <div class="terminal-bar">
+                        <span class="dot red"></span>
+                        <span class="dot yellow"></span>
+                        <span class="dot green"></span>
+                        <span class="terminal-title">bash</span>
+                    </div>
+                    <div class="terminal-content">
+                        <button class="copy-btn" onclick="copyToClipboard(this, 'explainthisrepo owner/repo --detailed')">Copy</button>
+                        <span class="prompt">$</span> explainthisrepo owner/repo --detailed
+                    </div>
+                </div>
+
+                <h3 style="margin-top: 2.5rem;">Simple mode</h3>
+                <p>Prints only the simple output (no EXPLAIN.md):</p>
+                
+                <div class="terminal">
+                    <div class="terminal-bar">
+                        <span class="dot red"></span>
+                        <span class="dot yellow"></span>
+                        <span class="dot green"></span>
+                        <span class="terminal-title">bash</span>
+                    </div>
+                    <div class="terminal-content">
+                        <button class="copy-btn" onclick="copyToClipboard(this, 'explainthisrepo owner/repo --simple')">Copy</button>
+                        <span class="prompt">$</span> explainthisrepo owner/repo --simple
+                    </div>
+                </div>
+
+                <h3 style="margin-top: 2.5rem;">Stack detector</h3>
+                <p>Get a tech stack breakdown detected from repo signals. No AI explanation. Prints only.</p>
+                
+                <div class="terminal">
+                    <div class="terminal-bar">
+                        <span class="dot red"></span>
+                        <span class="dot yellow"></span>
+                        <span class="dot green"></span>
+                        <span class="terminal-title">bash</span>
+                    </div>
+                    <div class="terminal-content">
+                        <button class="copy-btn" onclick="copyToClipboard(this, 'explainthisrepo owner/repo --stack')">Copy</button>
+                        <span class="prompt">$</span> explainthisrepo owner/repo --stack
+                    </div>
+                </div>
+
+                <h3 style="margin-top: 2.5rem;">Version</h3>
+                <p>Print the installed version:</p>
+                
+                <div class="terminal">
+                    <div class="terminal-bar">
+                        <span class="dot red"></span>
+                        <span class="dot yellow"></span>
+                        <span class="dot green"></span>
+                        <span class="terminal-title">bash</span>
+                    </div>
+                    <div class="terminal-content">
+                        <button class="copy-btn" onclick="copyToClipboard(this, 'explainthisrepo --version')">Copy</button>
+                        <span class="prompt">$</span> explainthisrepo --version
+                    </div>
+                </div>
+
+                <h3 style="margin-top: 2.5rem;">Doctor</h3>
+                <p>Check environment + connectivity (useful for debugging):</p>
+                
+                <div class="terminal">
+                    <div class="terminal-bar">
+                        <span class="dot red"></span>
+                        <span class="dot yellow"></span>
+                        <span class="dot green"></span>
+                        <span class="terminal-title">bash</span>
+                    </div>
+                    <div class="terminal-content">
+                        <button class="copy-btn" onclick="copyToClipboard(this, 'explainthisrepo --doctor')">Copy</button>
+                        <span class="prompt">$</span> explainthisrepo --doctor
+                    </div>
+                </div>
+            </section>
+
+            <hr class="divider">
+
+            <!-- CONFIGURATION -->
+            <section id="configuration">
+                <div class="section-header">
+                    <h2>Configuration</h2>
+                    <span class="section-badge">🔑 API Key</span>
+                </div>
+                <p>ExplainThisRepo uses Gemini models for code analysis.</p>
+                <p>Set your API key as an environment variable.</p>
+
                 <div class="install-option">
                     <h3>macOS / Linux</h3>
+                    
                     <div class="terminal">
                         <div class="terminal-bar">
-                            <span class="dot red"></span><span class="dot yellow"></span><span class="dot green"></span>
+                            <span class="dot red"></span>
+                            <span class="dot yellow"></span>
+                            <span class="dot green"></span>
                             <span class="terminal-title">bash</span>
                         </div>
                         <div class="terminal-content">
+                            <button class="copy-btn" onclick="copyToClipboard(this, 'export GEMINI_API_KEY=\"your_api_key_here\"')">Copy</button>
                             <span class="prompt">$</span> export GEMINI_API_KEY="your_api_key_here"
                         </div>
                     </div>
                 </div>
-            
+
                 <div class="install-option">
                     <h3>Windows (PowerShell)</h3>
+                    
                     <div class="terminal">
                         <div class="terminal-bar">
-                            <span class="dot red"></span><span class="dot yellow"></span><span class="dot green"></span>
+                            <span class="dot red"></span>
+                            <span class="dot yellow"></span>
+                            <span class="dot green"></span>
                             <span class="terminal-title">powershell</span>
                         </div>
                         <div class="terminal-content">
+                            <button class="copy-btn" onclick="copyToClipboard(this, 'setx GEMINI_API_KEY \"your_api_key_here\"')">Copy</button>
                             <span class="prompt">></span> setx GEMINI_API_KEY "your_api_key_here"
                         </div>
                     </div>
                 </div>
-            
+
                 <div class="alert-box">
-                    <strong>Restart Required:</strong> You must restart your terminal (close and reopen the window) after setting the key for changes to take effect.
+                    <strong>Note:</strong> Restart your terminal after setting the key.
                 </div>
             </section>
-            
-            <section id="termux" class="technical-wrapper">
-                <hr class="divider">
-            
-                <div class="tech-header" id="termux">
-                    <h2>📱 Termux (Android) Notes</h2>
-                    <span class="tag">Mobile</span>
+
+            <hr class="divider">
+
+            <!-- TERMUX -->
+            <section id="termux">
+                <div class="section-header">
+                    <h2>Termux (Android) Install Notes</h2>
+                    <span class="section-badge">📱 Mobile</span>
                 </div>
-            
                 <p>
-                    Termux has environment limitations that may prevent <code>pip install</code> from automatically linking the command to <code>$PREFIX/bin</code>.
+                    Termux has some environment limitations that can make <code>pip install explainthisrepo</code> fail to create the <code>explainthisrepo</code> command in <code>$PREFIX/bin</code>.
                 </p>
-            
+
                 <div class="install-option">
-                    <h3>Recommended Install</h3>
-                    <p>Install to your user directory and update your PATH.</p>
+                    <div class="option-header">
+                        <h3>Recommended install (Termux)</h3>
+                    </div>
                     
                     <div class="terminal">
                         <div class="terminal-bar">
-                            <span class="dot red"></span><span class="dot yellow"></span><span class="dot green"></span>
+                            <span class="dot red"></span>
+                            <span class="dot yellow"></span>
+                            <span class="dot green"></span>
                             <span class="terminal-title">termux</span>
                         </div>
                         <div class="terminal-content">
-                            <span class="prompt">$</span> pip install --user -U explainthisrepo<br><br>
-                            <span class="comment"># Add user bin to PATH</span><br>
+                            <button class="copy-btn" onclick="copyToClipboard(this, 'pip install --user -U explainthisrepo')">Copy</button>
+                            <span class="prompt">$</span> pip install --user -U explainthisrepo
+                        </div>
+                    </div>
+
+                    <p style="margin-top: 1rem;">Make sure your user bin directory is on your PATH:</p>
+                    
+                    <div class="terminal">
+                        <div class="terminal-bar">
+                            <span class="dot red"></span>
+                            <span class="dot yellow"></span>
+                            <span class="dot green"></span>
+                            <span class="terminal-title">termux</span>
+                        </div>
+                        <div class="terminal-content">
+                            <button class="copy-btn" onclick="copyToClipboard(this, 'export PATH=\"$HOME/.local/bin:$PATH\"')">Copy</button>
                             <span class="prompt">$</span> export PATH="$HOME/.local/bin:$PATH"
                         </div>
                     </div>
-            
+
                     <div class="alert-box">
-                        <strong>Tip:</strong> Add the export command above to your <code>~/.bashrc</code> or <code>~/.zshrc</code> file so it persists after you close the app.
+                        <strong>Tip:</strong> Add the PATH export to your <code>~/.bashrc</code> or <code>~/.zshrc</code> so it persists.
                     </div>
                 </div>
-            
+
                 <div class="install-option">
                     <h3>Alternative (No PATH changes)</h3>
-                    <p>If you don't want to modify your PATH, you can run the tool as a Python module:</p>
+                    <p>If you do not want to modify PATH, you can run ExplainThisRepo as a module:</p>
                     
                     <div class="terminal">
                         <div class="terminal-bar">
-                            <span class="dot red"></span><span class="dot yellow"></span><span class="dot green"></span>
+                            <span class="dot red"></span>
+                            <span class="dot yellow"></span>
+                            <span class="dot green"></span>
                             <span class="terminal-title">termux</span>
                         </div>
                         <div class="terminal-content">
+                            <button class="copy-btn" onclick="copyToClipboard(this, 'python -m explain_this_repo owner/repo')">Copy</button>
                             <span class="prompt">$</span> python -m explain_this_repo owner/repo
                         </div>
                     </div>
                 </div>
-            
+
                 <div class="install-option">
-                    <h3>Gemini Support (Optional)</h3>
-                    <p>
-                        Installing full Gemini support may require building Rust-based dependencies, which can take several minutes on a mobile device.
-                    </p>
+                    <h3>Gemini support on Termux (Optional)</h3>
+                    <p>Installing Gemini support may require building Rust-based dependencies on Android, which can take time on first install:</p>
                     
                     <div class="terminal">
                         <div class="terminal-bar">
-                            <span class="dot red"></span><span class="dot yellow"></span><span class="dot green"></span>
+                            <span class="dot red"></span>
+                            <span class="dot yellow"></span>
+                            <span class="dot green"></span>
                             <span class="terminal-title">termux</span>
                         </div>
                         <div class="terminal-content">
+                            <button class="copy-btn" onclick="copyToClipboard(this, 'pip install --user -U \"explainthisrepo[gemini]\"')">Copy</button>
                             <span class="prompt">$</span> pip install --user -U "explainthisrepo[gemini]"
                         </div>
                     </div>
                 </div>
-            
             </section>
         </main>
     </div>
 
+    <script>
+        // Theme Toggle - WORKING VERSION
+        (function() {
+            'use strict';
+            
+            function initTheme() {
+                const themeToggle = document.getElementById('themeToggle');
+                const html = document.documentElement;
+                const sunIcon = document.querySelector('.sun-icon');
+                const moonIcon = document.querySelector('.moon-icon');
+                
+                if (!themeToggle || !sunIcon || !moonIcon) {
+                    console.error('Theme toggle elements not found');
+                    return;
+                }
+                
+                // Get saved theme or default to light
+                let currentTheme = localStorage.getItem('theme') || 'light';
+                
+                // Function to update UI based on theme
+                function updateTheme(theme) {
+                    html.setAttribute('data-theme', theme);
+                    
+                    if (theme === 'dark') {
+                        sunIcon.style.display = 'none';
+                        moonIcon.style.display = 'block';
+                    } else {
+                        sunIcon.style.display = 'block';
+                        moonIcon.style.display = 'none';
+                    }
+                }
+                
+                // Apply initial theme
+                updateTheme(currentTheme);
+                
+                // Toggle theme on click
+                themeToggle.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    currentTheme = currentTheme === 'light' ? 'dark' : 'light';
+                    localStorage.setItem('theme', currentTheme);
+                    updateTheme(currentTheme);
+                });
+            }
+            
+            // Initialize when DOM is ready
+            if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', initTheme);
+            } else {
+                initTheme();
+            }
+        })();
+
+        // Copy to clipboard functionality
+        function copyToClipboard(button, text) {
+            navigator.clipboard.writeText(text).then(() => {
+                const originalText = button.textContent;
+                button.textContent = 'Copied!';
+                button.classList.add('copied');
+                
+                setTimeout(() => {
+                    button.textContent = originalText;
+                    button.classList.remove('copied');
+                }, 2000);
+            }).catch(err => {
+                console.error('Failed to copy:', err);
+                button.textContent = 'Failed';
+                setTimeout(() => {
+                    button.textContent = 'Copy';
+                }, 2000);
+            });
+        }
+
+        // Active navigation highlighting
+        const sections = document.querySelectorAll('section[id]');
+        const navLinks = document.querySelectorAll('.sidebar a[href^="#"]');
+
+        function highlightNav() {
+            let current = '';
+            sections.forEach(section => {
+                const sectionTop = section.offsetTop;
+                const sectionHeight = section.clientHeight;
+                if (window.pageYOffset >= sectionTop - 100) {
+                    current = section.getAttribute('id');
+                }
+            });
+
+            navLinks.forEach(link => {
+                link.classList.remove('active');
+                if (link.getAttribute('href') === `#${current}`) {
+                    link.classList.add('active');
+                }
+            });
+        }
+
+        window.addEventListener('scroll', highlightNav);
+        window.addEventListener('load', highlightNav);
+    </script>
 </body>
 </html>


### PR DESCRIPTION
- Add functional light/dark theme toggle with localStorage persistence
- Implement shadcn-inspired design system with clean badges
- Add copy-to-clipboard functionality for all code examples
- Make brand name clickable to redirect to landing page
- Add all new CLI modes (--quick, --detailed, --simple, --stack, --doctor)
- Add flexible input format examples section
- Improve responsive design for mobile devices
- Update navigation with proper section organization
- Apply consistent color theming across all components