### PR TITLE
refactor: move brand and theme toggle to top header

### DIFF
--- a/apps/web/public/docs/index.html
+++ b/apps/web/public/docs/index.html
@@ -108,7 +108,7 @@
         right: 0;
         left: 280px;
         display: flex;
-        justify-content: flex-end;
+        justify-content: space-between;
         align-items: center;
         padding: 16px 20px;
         gap: 1rem;
@@ -116,6 +116,67 @@
         border-bottom: 1px solid var(--border-color);
         z-index: 100;
         transition: background-color 0.3s ease, border-color 0.3s ease;
+    }
+
+    .header-left {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+    }
+
+    .header-right {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+    }
+
+    .brand {
+        font-weight: 800;
+        font-size: 1.25rem;
+        color: var(--text-dark);
+        letter-spacing: -0.02em;
+    }
+
+    .brand-link {
+        color: var(--text-dark);
+        text-decoration: none;
+        transition: color 0.2s ease;
+    }
+
+    .brand-link:hover {
+        color: var(--primary);
+    }
+
+    .theme-toggle {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        width: 36px;
+        height: 36px;
+        border-radius: 8px;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: all 0.3s ease;
+        color: var(--text-dark);
+    }
+
+    .theme-toggle:hover {
+        background: var(--border-color);
+        transform: scale(1.05);
+    }
+
+    .theme-toggle svg {
+        width: 18px;
+        height: 18px;
+    }
+
+    .sun-icon {
+        display: block;
+    }
+
+    .moon-icon {
+        display: none;
     }
 
     .github-btn {
@@ -148,68 +209,12 @@
         background: var(--bg-sidebar);
         border-right: 1px solid var(--border-color);
         padding: 2rem 1.5rem;
+        padding-top: 5rem;
         position: fixed;
         height: 100vh;
         width: 280px;
         overflow-y: auto;
         transition: background-color 0.3s ease, border-color 0.3s ease;
-    }
-
-    .brand {
-        font-weight: 800;
-        font-size: 1.25rem;
-        margin-bottom: 2.5rem;
-        color: var(--text-dark);
-        letter-spacing: -0.02em;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        width: 100%;
-    }
-
-    .brand-link {
-        color: var(--text-dark);
-        text-decoration: none;
-        transition: color 0.2s ease;
-        flex: 1;
-    }
-
-    .brand-link:hover {
-        color: var(--primary);
-    }
-
-    .theme-toggle {
-        background: var(--bg-secondary);
-        border: 1px solid var(--border-color);
-        width: 36px;
-        height: 36px;
-        border-radius: 8px;
-        cursor: pointer;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        transition: all 0.3s ease;
-        color: var(--text-dark);
-        flex-shrink: 0;
-        margin-left: auto;
-    }
-
-    .theme-toggle:hover {
-        background: var(--border-color);
-        transform: scale(1.05);
-    }
-
-    .theme-toggle svg {
-        width: 18px;
-        height: 18px;
-    }
-
-    .sun-icon {
-        display: block;
-    }
-
-    .moon-icon {
-        display: none;
     }
 
     .nav-section {
@@ -285,10 +290,10 @@
 
     /* --- TYPOGRAPHY --- */
     h1 {
-        font-size: clamp(2rem, 5vw, 2.75rem);
-        font-weight: 800;
-        letter-spacing: -0.03em;
-        margin-bottom: 1rem;
+        font-size: clamp(1.5rem, 4vw, 2rem);
+        font-weight: 700;
+        letter-spacing: -0.02em;
+        margin-bottom: 1.25rem;
         color: var(--text-dark);
     }
 
@@ -645,6 +650,7 @@
             width: 100%;
             height: auto;
             padding: 1.5rem;
+            padding-top: 5rem;
             border-right: none;
             border-bottom: 1px solid var(--border-color);
         }
@@ -664,13 +670,20 @@
             padding: 5rem 1rem 1.5rem;
         }
         h1 {
-            font-size: 1.75rem;
+            font-size: 1.5rem;
         }
         h2 {
             font-size: 1.5rem;
         }
         .top-header {
             padding: 12px 16px;
+        }
+        .brand {
+            font-size: 1rem;
+        }
+        .header-left,
+        .header-right {
+            gap: 0.5rem;
         }
     }
 
@@ -682,18 +695,14 @@
 </head>
 <body>
     <div class="docs-layout">
-        <!-- HEADER WITH GITHUB BUTTON -->
+        <!-- HEADER WITH BRAND, THEME TOGGLE, AND GITHUB BUTTON -->
         <header class="top-header">
-            <a class="github-btn" href="https://github.com/calchiwo/ExplainThisRepo" target="_blank" rel="noopener noreferrer">
-                <svg height="18" viewBox="0 0 16 16" width="18" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 005.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-                <span>Star on GitHub</span>
-            </a>
-        </header>
-
-        <!-- SIDEBAR -->
-        <aside class="sidebar">
-            <div class="brand">
-                <span class="brand-link">ExplainThisRepo</span>
+            <div class="header-left">
+                <div class="brand">
+                    <a href="#" class="brand-link">ExplainThisRepo</a>
+                </div>
+            </div>
+            <div class="header-right">
                 <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
                     <svg class="sun-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"></path>
@@ -702,7 +711,15 @@
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path>
                     </svg>
                 </button>
+                <a class="github-btn" href="https://github.com/calchiwo/ExplainThisRepo" target="_blank" rel="noopener noreferrer">
+                    <svg height="18" viewBox="0 0 16 16" width="18" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 005.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+                    <span>Star on GitHub</span>
+                </a>
             </div>
+        </header>
+
+        <!-- SIDEBAR -->
+        <aside class="sidebar">
             <nav>
                 <div class="nav-section">
                     <p class="nav-label">Overview</p>


### PR DESCRIPTION
- Move ExplainThisRepo brand from sidebar to header left
- Move theme toggle from sidebar to header right alongside GitHub button
- Reduce Introduction heading size to match other h2 headings
- Add header layout containers (.header-left, .header-right)
- Update sidebar padding-top to 5rem for fixed header spacing
- Maintain responsive behavior for mobile breakpoints