### PR TITLE
refactor(cli-node): migrate to commander and harden CLI architecture

### DIFF
--- a/node_version/package-lock.json
+++ b/node_version/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "explainthisrepo",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "explainthisrepo",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "axios": "^1.13.2",
+        "commander": "^14.0.3",
         "dotenv": "^17.2.3"
       },
       "bin": {
@@ -83,6 +84,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/delayed-stream": {

--- a/node_version/package.json
+++ b/node_version/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explainthisrepo",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "ExplainThisRepo is a CLI developer tool to explain any GitHub repository in plain English",
   "license": "MIT",
   "type": "module",
@@ -45,6 +45,7 @@
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
     "axios": "^1.13.2",
+    "commander": "^14.0.3",
     "dotenv": "^17.2.3"
   },
   "devDependencies": {


### PR DESCRIPTION
- Replace manual process.argv parsing with commander
- Enable order-independent flags
- Define structured CLI with positional repository argument
- Enforce mutual exclusivity for mode flags (--quick, --simple, --detailed, --stack)
- Fix doctor exit code to require both GitHub and Gemini checks
- Remove brittle argument-length branching logic
- Eliminate silent exception swallowing and add warning logs
- Wrap stack mode in structured error handling
- Flatten nested try/catch blocks for clarity
- Standardize error output to console.error and warnings to console.warn
- Replace program.help() with program.error() for invalid usage
- Align Node CLI behavior and structure with pip implementation

Ref #118

No behavior changes intended.