### PR TITLE
refactor(pip): make `--simple` mode single call and remove LLM chaining

### DIFF
--- a/explain_this_repo/cli.py
+++ b/explain_this_repo/cli.py
@@ -256,7 +256,38 @@ def main():
         print(output.strip())
         return
 
-    # NORMAL/DETAILED path: repo reader (safe)
+    # SIMPLE MODE
+    if args.simple:
+        try:
+            read_result = read_repo_signal_files(owner, repo)
+        except Exception as e:
+            print(f"warning: could not read repository files: {e}")
+            read_result = None
+
+        prompt = build_simple_prompt(
+            repo_name=repo_data.get("full_name"),
+            description=repo_data.get("description"),
+            readme=readme,
+            tree_text=read_result.tree_text if read_result else None,
+        )
+
+        print("Generating explanation...")
+
+        try:
+            output = generate_explanation(prompt)
+        except Exception as e:
+            print("Failed to generate explanation.")
+            print(f"error: {e}")
+            print("\nfix:")
+            print("- Ensure GEMINI_API_KEY is set")
+            print("- Or run: explainthisrepo --doctor")
+            raise SystemExit(1)
+
+        print("Simple summary 🎉")
+        print(output.strip())
+        return
+
+    # NORMAL / DETAILED MODE
     try:
         read_result = read_repo_signal_files(owner, repo)
     except Exception as e:
@@ -284,26 +315,6 @@ def main():
         print("- Or run: explainthisrepo --doctor")
         raise SystemExit(1)
 
-    # SIMPLE MODE: summarize the long output, no file write
-    if args.simple:
-        print("Summarizing...")
-        simple_prompt = build_simple_prompt(output)
-
-        try:
-            simple_output = generate_explanation(simple_prompt)
-        except Exception as e:
-            print("Failed to generate explanation.")
-            print(f"error: {e}")
-            print("\nfix:")
-            print("- Ensure GEMINI_API_KEY is set")
-            print("- Or run: explainthisrepo --doctor")
-            raise SystemExit(1)
-
-        print("Simple summary 🎉")
-        print(simple_output.strip())
-        return
-
-    # NORMAL / DETAILED: write EXPLAIN.md
     print("Writing EXPLAIN.md...")
     write_output(output)
 

--- a/explain_this_repo/prompt.py
+++ b/explain_this_repo/prompt.py
@@ -88,14 +88,29 @@ Rules:
     return prompt.strip()
 
 
-def build_simple_prompt(long_explanation: str) -> str:
-    return f"""
+def build_simple_prompt(
+    repo_name: str,
+    description: str | None,
+    readme: str | None,
+    tree_text: str | None = None,
+) -> str:
+    readme_content = (readme or "No README provided")[:4000]
+    tree_content = (tree_text or "No file tree provided")[:1500]
+
+    prompt = f"""
 You are a senior software engineer.
 
-Rewrite the long repository explanation below into a SIMPLE version in the exact style specified.
+Summarize this GitHub repository in a concise bullet-point format.
 
-Input explanation:
-{long_explanation}
+Repository:
+- Name: {repo_name}
+- Description: {description or "No description provided"}
+
+README content:
+{readme_content}
+
+Repo structure:
+{tree_content}
 
 Output style rules:
 - Plain English.
@@ -107,12 +122,13 @@ Key points from the repo:
 - Each bullet MUST start with: ⬤
 - Each bullet title should be 1–3 words only (example: "Purpose", "Stack", "Entrypoints", "How it works", "Usage", "Structure").
 - Each bullet body should be 1–2 lines max.
-- If the input contains architecture/pipeline steps, capture them naturally.
-- If the input does NOT contain architecture/pipeline steps, do NOT invent them.
+- Base bullets strictly on the provided README and structure.
+- Do NOT invent features, architecture, or details not present in the input.
 - Optional: end with one extra line starting with:
 Also interesting:
-- Do NOT add features not present in the input.
 - No quotes.
 
 Make it feel like a human developer explaining to another developer in simple terms.
 """.strip()
+
+    return prompt


### PR DESCRIPTION
- Remove double LLM generation in `--simple` mode
- Remove long explanation to summarization flow
- Change `build_simple_prompt` to accept repo metadata directly
- Replace old `build_simple_prompt(long_explanation)` signature
- Move --simple branch above normal/detailed execution path
- Execute exactly one LLM call in simple mode
- Add README and tree truncation safeguards
- Decouple simple mode from full prompt builder
- Standardize CLI execution path across quick/simple/default modes
- Improve architectural separation between prompt builders

Closes #120