### PR TITLE
fix(cli-node): restore default repository command routing

### DIFF
--- a/node_version/cli.ts
+++ b/node_version/cli.ts
@@ -31,7 +31,6 @@ function resolveRepoTarget(target: string): { owner: string; repo: string } {
     target = target.replace("http//", "http://");
   }
 
-  // Case 1: SSH clone URL
   if (target.startsWith("git@github.com:")) {
     const p = target.replace("git@github.com:", "");
     const [owner, repoRaw] = p.split("/", 2);
@@ -39,12 +38,10 @@ function resolveRepoTarget(target: string): { owner: string; repo: string } {
     return { owner, repo: repoRaw.replace(/\.git$/, "") };
   }
 
-  // Case 2: github.com/owner/repo
   if (target.startsWith("github.com/")) {
     target = "https://" + target;
   }
 
-  // Case 3: Full URL
   if (target.startsWith("http://") || target.startsWith("https://")) {
     const url = new URL(target);
 
@@ -60,7 +57,6 @@ function resolveRepoTarget(target: string): { owner: string; repo: string } {
     return { owner: parts[0], repo: parts[1].replace(/\.git$/, "") };
   }
 
-  // Case 4: owner/repo
   const parts = target.split("/");
   if (parts.length === 2 && parts[0] && parts[1]) {
     return { owner: parts[0], repo: parts[1] };
@@ -81,10 +77,6 @@ function getPkgVersion(): string {
   } catch {
     return "unknown";
   }
-}
-
-function printVersion(): void {
-  console.log(getPkgVersion());
 }
 
 function hasEnv(key: string): boolean {
@@ -165,53 +157,16 @@ async function generateWithExit(prompt: string): Promise<string> {
   }
 }
 
-async function main(): Promise<void> {
-  const program = new Command();
-
-  program
-    .name("explainthisrepo")
-    .description("CLI that generates plain English explanations of any codebase")
-    .version(getPkgVersion(), "-v, --version", "Show version")
-    .argument("[repository]", "GitHub repository (owner/repo or URL) or local directories")
-    .option("--doctor", "Run diagnostics")
-    .option("--quick", "Quick summary mode")
-    .option("--simple", "Simple summary mode")
-    .option("--detailed", "Detailed explanation mode")
-    .option("--stack", "Stack detection mode")
-    .addHelpText(
-      "after",
-      `
-Examples:
-  $ explainthisrepo owner/repo
-  $ explainthisrepo https://github.com/owner/repo
-  $ explainthisrepo github.com/owner/repo
-  $ explainthisrepo git@github.com:owner/repo.git
-  $ explainthisrepo owner/repo --detailed
-  $ explainthisrepo owner/repo --quick
-  $ explainthisrepo owner/repo --simple
-  $ explainthisrepo owner/repo --stack
-  $ explainthisrepo .
-  $ explainthisrepo ./path/to/directory
-  $ explainthisrepo . --stack
-  $ explainthisrepo --doctor`
-    );
-
-  program
-    .command("init")
-    .description("Initialize configuration with Gemini API key")
-    .action(async () => {
-      await runInit();
-    });
-
-  program.parse(process.argv);
-
-  if (process.argv[2] === "init") {
-    return;
+async function runAnalysis(
+  repository: string,
+  options: {
+    doctor?: boolean;
+    quick?: boolean;
+    simple?: boolean;
+    detailed?: boolean;
+    stack?: boolean;
   }
-
-  const options = program.opts();
-  const repository = program.args[0];
-
+): Promise<void> {
   if (options.doctor) {
     const code = await runDoctor();
     process.exit(code);
@@ -227,10 +182,6 @@ Examples:
   if (modeFlags.length > 1) {
     console.error("error: only one mode flag can be used at a time");
     process.exit(1);
-  }
-
-  if (!repository) {
-    program.error("repository argument required (or use `init` to set up API key)");
   }
 
   const local = fs.existsSync(repository);
@@ -414,4 +365,60 @@ Examples:
   console.log("Open EXPLAIN.md to read it.");
 }
 
-main();
+const program = new Command();
+
+program
+  .name("explainthisrepo")
+  .description("CLI that generates plain English explanations of any codebase")
+  .version(getPkgVersion(), "-v, --version", "Show version")
+  .argument("[repository]", "GitHub repository (owner/repo or URL) or local directories")
+  .option("--doctor", "Run diagnostics")
+  .option("--quick", "Quick summary mode")
+  .option("--simple", "Simple summary mode")
+  .option("--detailed", "Detailed explanation mode")
+  .option("--stack", "Stack detection mode")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  $ explainthisrepo owner/repo
+  $ explainthisrepo https://github.com/owner/repo
+  $ explainthisrepo github.com/owner/repo
+  $ explainthisrepo git@github.com:owner/repo.git
+  $ explainthisrepo owner/repo --detailed
+  $ explainthisrepo owner/repo --quick
+  $ explainthisrepo owner/repo --simple
+  $ explainthisrepo owner/repo --stack
+  $ explainthisrepo .
+  $ explainthisrepo ./path/to/directory
+  $ explainthisrepo . --stack
+  $ explainthisrepo --doctor`
+  )
+  .action(async (repository: string | undefined, options: {
+    doctor?: boolean;
+    quick?: boolean;
+    simple?: boolean;
+    detailed?: boolean;
+    stack?: boolean;
+  }) => {
+    if (options.doctor) {
+      const code = await runDoctor();
+      process.exit(code);
+    }
+
+    if (!repository) {
+      program.error("repository argument required (or use `init` to set up API key)");
+      return;
+    }
+
+    await runAnalysis(repository, options);
+  });
+
+program
+  .command("init")
+  .description("Initialize configuration with Gemini API key")
+  .action(async () => {
+    await runInit();
+  });
+
+program.parseAsync(process.argv);

--- a/node_version/package-lock.json
+++ b/node_version/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "explainthisrepo",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "explainthisrepo",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",

--- a/node_version/package.json
+++ b/node_version/package.json
@@ -1,7 +1,7 @@
 {
   "name": "explainthisrepo",
-  "version": "0.6.1",
-  "description": "CLI that generates plain English explanations of any codebase",
+  "version": "0.6.2",
+  "description": "CLI that generates plain-English explanations of any codebase",
   "license": "MIT",
   "type": "module",
   "author": "Caleb Wodi <calebwodi33@gmail.com>",


### PR DESCRIPTION
This PR fixes a CLI routing regression introduced when the `init` subcommand was added.

Commander was treating repository arguments (e.g. `owner/repo`) as subcommands because the root command did not define an explicit action handler. As a result, normal analysis commands failed with “unknown command”.

The CLI routing is now structured with:
- An explicit root action that handles repository analysis and mode flags
- A fully isolated `init` subcommand for bootstrap configuration
- No post-parse argument inspection or fallthrough execution

This restores expected behavior for:
- explainthisrepo owner/repo
- explainthisrepo owner/repo --quick
- explainthisrepo owner/repo --simple
- explainthisrepo .
- explainthisrepo init