### PR TITLE
Add CLI aliases for Node.js CLI parity

### DIFF
--- a/node_version/package-lock.json
+++ b/node_version/package-lock.json
@@ -19,6 +19,8 @@
         "toml": "^3.0.0"
       },
       "bin": {
+        "etr": "dist/cli.js",
+        "explain-this-repo": "dist/cli.js",
         "explainthisrepo": "dist/cli.js"
       },
       "devDependencies": {

--- a/node_version/package.json
+++ b/node_version/package.json
@@ -1,7 +1,7 @@
 {
   "name": "explainthisrepo",
-  "version": "0.9.1",
-  "description": "CLI that generates plain-English explanations of any codebase",
+  "version": "0.9.2",
+  "description": "The fastest way to understand any codebase in plain English. Not blind AI summarization",
   "license": "MIT",
   "type": "module",
   "author": "Caleb Wodi <calebwodi33@gmail.com>",
@@ -27,7 +27,9 @@
     "developer-tools"
   ],
   "bin": {
-    "explainthisrepo": "dist/cli.js"
+    "explainthisrepo": "dist/cli.js",
+    "explain-this-repo": "dist/cli.js",
+    "etr": "dist/cli.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
- add `explain-this-repo` alias for readability
- add `etr` alias for faster usage
- map all commands to same CLI entrypoint
- align Node CLI with Python version